### PR TITLE
(docs) Add makeUnprivilegedEditor example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,15 @@ class Editor extends React.Component {
 }
 ```
 
+To make an unprivileged editor instance use the ref to pass in the editor:
+
+```jsx
+const editor = this.reactQuillRef.getEditor();
+const unprivilegedEditor = this.reactQuillRef.makeUnprivilegedEditor(editor);
+// You may now use the unprivilegedEditor proxy methods
+unprivilegedEditor.getText();
+```
+
 </details>
 
 ### The unprivileged editor


### PR DESCRIPTION
Hi 👋 

Thanks for this wrapper around Quill! I wanted to add an example of how to make the unprivileged editor because it didn't seem obvious to me at all how you do that (particularly got tripped up on not realizing I needed to pass the editor to the `makeUnprivilegedEditor()` fn).

Hope this help!